### PR TITLE
Improved use of the touch-action css property

### DIFF
--- a/src/scroller.css
+++ b/src/scroller.css
@@ -21,10 +21,6 @@
     box-sizing: border-box;
 }
 
-html {
-    -ms-touch-action: none;
-}
-
 .surface {
     position: absolute;
     -webkit-transform-origin: center center;
@@ -81,6 +77,16 @@ html {
     height: 100%;
 }
 
+.scroll-horizontal {
+    -ms-touch-action: pan-y;
+    touch-action: pan-y;
+}
+
+.scroll-vertical {
+    -ms-touch-action: pan-x;
+    touch-action: pan-x;
+}
+
 .pullToRefresh {
     -webkit-transform : translate3d(0,0,0);
     -moz-transform    : translate3d(0,0,0);
@@ -107,7 +113,7 @@ html {
     display: inline-block;
     background-position: 50%;
     background-repeat: no-repeat;
-    border-radius: 5px; 
+    border-radius: 5px;
 
     -webkit-transition : -webkit-transform 300ms;
     -moz-transition    : -moz-transform 300ms;


### PR DESCRIPTION
The touch-action property helps detecting/preventing touch actions. Setting the `none` value on the HTML makes the whole page none-scrollable on Windows Phone. I've replaced it to set it to the correct value for the horizontal/vertical scrollers. This also might improve detection/preventing the default of the touches on Chrome Mobile and Firefox Mobile.

Also, my IDE did some small cleanup on spaces and a empty newline.
