### PR TITLE
Logic flip preventing unending loop

### DIFF
--- a/src/plugins/infinite-loading.js
+++ b/src/plugins/infinite-loading.js
@@ -114,10 +114,10 @@
 
             if (this.scrollVertical) {
                 pos  = y;
-                size = this.scrollerWidth;
+                size = this.scrollerHeight;
             } else {
                 pos  = x;
-                size = this.scrollerHeight;
+                size = this.scrollerWidth;
             }
 
             threshold = config.threshold || 3 * size;


### PR DESCRIPTION
Currently loads more surfaces on wrong dimension, which doesn't increase when more surfaces are added. This means that on every scroll event this._triggerInfiniteLoadingDataProvider is always called
