### PR TITLE
add reference to scroller to ptr/ptl callbacks

### DIFF
--- a/src/plugins/pull-to-load-more.js
+++ b/src/plugins/pull-to-load-more.js
@@ -38,7 +38,7 @@
             labelSubtitle : '',
             labelError    : 'Error on pull to load more'
         },
-        
+
         PULL_TO_SNAP_TIME  = 200,
         ERROR_TIMEOUT      = 1000,
         CLASS_UPDATE_STATE = 'update',
@@ -48,7 +48,7 @@
         CLASS_LABEL        = 'label',
         CLASS_SUBTITLE     = 'sub',
         CLASS_PTL          = 'pullToLoadMore';
-    
+
     function PullToLoadMore() {}
 
     PullToLoadMore.prototype = {
@@ -76,7 +76,7 @@
             }
             this.opts.pullToLoadMoreConfig = ptlConfig;
         },
-        
+
         triggerPTL: function () {
             //set waiting state
             if (!this._ptlLoading) {
@@ -242,7 +242,7 @@
                 };
 
             if (ptrDataProvider) {
-                ptrDataProvider(callback);
+                ptrDataProvider(callback, self);
             } else {
                 w.setTimeout(function (){
                     self._ptlExecTriggerCallback('no fnc');

--- a/src/plugins/pull-to-refresh.js
+++ b/src/plugins/pull-to-refresh.js
@@ -16,7 +16,7 @@
 (function (w) {
     'use strict';
     w || (w = window);
-    
+
     // NAMESPACES
     var SCROLLER = w.__S || (w.__S = {}),
         RAF      = w.requestAnimationFrame,
@@ -49,7 +49,7 @@
         CLASS_LABEL        = 'label',
         CLASS_SUBTITLE     = 'sub',
         CLASS_PTR          = 'pullToRefresh';
-    
+
     function PullToRefresh() {}
 
     PullToRefresh.DEFAULTS = CONFIG_DEFAULTS;
@@ -147,7 +147,7 @@
                 this._iosTouching = false;
                 this._end(e);
             }.bind(this));
-            
+
         },
         //TODO: FIX clicking for PTR
         _appendPullToRefresh: function () {
@@ -246,10 +246,10 @@
                 return this._needsPullToRefresh(y);
             }
 
-            if (isPTRNative) { 
+            if (isPTRNative) {
                 if (y > -this._ptrSize) {
                     this.ptrDOM.style[STYLES.transform] = 'translate3d(0,' + (50 + y) + 'px,0)';
-                }   
+                }
             }
         },
         _onScrollEndPTR: function (e) {
@@ -291,7 +291,7 @@
                 };
 
             if (ptrDataProvider) {
-                ptrDataProvider(callback);
+                ptrDataProvider(callback, self);
             } else {
                 w.setTimeout(function (){
                     self._ptrExecTriggerCallback('handler not defined');
@@ -316,7 +316,7 @@
                     self._resetPosition(self._ptrSnapTime);
                 });
             }
-            
+
         },
         /*
         * ==================================


### PR DESCRIPTION
When using multiple scrollers or nested scrollers, it's useful to know which scroller was triggered by ptr/ptl. This adds a reference to the activated scroller to the ptr/ptl functions.
